### PR TITLE
Added new Issue Templates for contributors

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,38 @@
+name: Bug report 🐞
+description: File a bug report
+title: "[Bug]: "
+body:
+  - type: checkboxes
+    id: existing-issue
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for the bug you encountered.
+      options:
+        - label: I have searched the existing issues
+          required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A concise description of what you are experiencing.
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Add ScreenShots
+      description: Add sufficient ScreenShots to explain your issue.
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Record
+      options:
+        - label: "I agree to follow this project's Code of Conduct"
+          required: true
+        - label: "I'm a GSSOC'24 Extd contributor"
+          required: False
+        - label: "I want to work on this issue"
+          required: False
+        - label: "I'm willing to provide further clarification or assistance if needed."
+          required: False

--- a/.github/ISSUE_TEMPLATE/documentation_update.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_update.yml
@@ -1,0 +1,61 @@
+name: 📝 Documentation Update
+description: Improve Documentation
+title: "[Documentation Update]: "
+body:
+  - type: checkboxes
+    id: existing-issue
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for the updates you want to make.
+      options:
+        - label: I have searched the existing issues
+          required: true
+  - type: textarea
+    id: issue-description
+    attributes:
+      label: Issue Description
+      description: Please provide a clear description of the documentation update you are suggesting.
+      placeholder: Describe the improvement or correction you'd like to see in the documentation.
+    validations:
+      required: true
+  - type: textarea
+    id: suggested-change
+    attributes:
+      label: Suggested Change
+      description: Provide details of the proposed change to the documentation.
+      placeholder: Explain how the documentation should be updated or corrected.
+    validations:
+      required: true
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Rationale
+      description: Why is this documentation update necessary or beneficial?
+      placeholder: Explain the importance or reasoning behind the suggested change.
+    validations:
+      required: False
+  - type: dropdown
+    id: urgency
+    attributes:
+      label: Urgency
+      description: How urgently do you believe this documentation update is needed?
+      options:
+        - High
+        - Medium
+        - Low
+      default: 0
+    validations:
+      required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Record
+      options:
+        - label: "I agree to follow this project's Code of Conduct"
+          required: true
+        - label: "I'm a GSSOC'24 Extd contributor"
+          required: False
+        - label: "I want to work on this issue"
+          required: False
+        - label: "I'm willing to provide further clarification or assistance if needed."
+          required: False

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,59 @@
+name: ✨ Feature Request
+description: Suggest a feature
+title: "[Feature Request]: "
+body:
+  - type: checkboxes
+    id: existing-issue
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for this feature.
+      options:
+        - label: I have searched the existing issues
+          required: true
+  - type: textarea
+    id: feature-description
+    attributes:
+      label: Feature Description
+      description: Please provide a detailed description of the feature you are requesting.
+      placeholder: Describe the new feature or enhancement you'd like to see.
+    validations:
+      required: true
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use Case
+      description: How would this feature enhance your use of the project?
+      placeholder: Describe a specific use case or scenario where this feature would be beneficial.
+    validations:
+      required: true
+  - type: textarea
+    id: benefits
+    attributes:
+      label: Benefits
+      description: What benefits would this feature bring to the project or community?
+      placeholder: Explain the advantages of implementing this feature.
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: How important is this feature to you?
+      options:
+        - High
+        - Medium
+        - Low
+      default: 0
+    validations:
+      required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Record
+      options:
+        - label: "I agree to follow this project's Code of Conduct"
+          required: true
+        - label: "I'm a GSSOC'24 Extd contributor"
+          required: False
+        - label: "I want to work on this issue"
+          required: False
+        - label: "I'm willing to provide further clarification or assistance if needed."
+          required: False


### PR DESCRIPTION
Closes: #4 
- This PR adds new issue templates to the repository so now user's can create issues in the existing templates


![image](https://github.com/user-attachments/assets/f754700f-d2fe-4918-984f-842b78cc4fee)

![image](https://github.com/user-attachments/assets/4cccbc05-f0ba-4b64-a766-959ce3858775)