### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,22 @@ Don’t forget to star ⭐ the repository and follow the [OpenTekHub](https://gi
 Big thanks to all the contributors! 🎉
 
 <a href="https://github.com/OpenTekHub/blockchain/pulse"> <img align="center" src="https://contrib.rocks/image?max=100&repo=OpenTekHub/blockchain" /> </a> 
+
+![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/rainbow.png)
+
+
+## <img src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Smilies/Red%20Heart.png" width="35" height="35"> Stargazers
+
+<div align='left'>
+
+[![Stargazers repo roster for @OpenTekHub/blockchain](https://reporoster.com/stars/OpenTekHub/blockchain)](https://github.com/OpenTekHub/blockchain/stargazers)
+
+</div>
+
+## <img src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Smilies/Red%20Heart.png" width="35" height="35"> Forkers
+
+[![Forkers repo roster for @OpenTekHub/blockchain](https://reporoster.com/forks/OpenTekHub/blockchain)](https://github.com/OpenTekHub/blockchain/network/members)
+
+![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/rainbow.png)
+
+


### PR DESCRIPTION
adding Stargazers and Forkers section to readme.md

Issue Description
adding Stargazers and Forkers section to readme.md

PR Description
added Stargazers and Forkers section to readme.md


fixes #181 
close #181 

use case

1. Stargazers highlight the GitHub users' profiles who starred the repository.
2. And forkers show the people who have already forked the repository

![2024-10-22 (14)](https://github.com/user-attachments/assets/e95fe6f2-f619-4b3a-844e-c791abd3dcc3)
